### PR TITLE
Protect uploads dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ composer.lock
 vendor
 wp
 local-config.php
+/backup/uploads/*
+!/backup/uploads/.keep

--- a/scripts/Installer.php
+++ b/scripts/Installer.php
@@ -54,6 +54,10 @@ class Installer
                 'target' => '../../wp-content/plugins',
                 'link' => "{$projectRoot}/wp/wp-content/plugins",
             ),
+            array(
+                'target' => '../../backup/uploads',
+                'link' => "{$projectRoot}/wp/wp-content/uploads",
+            )
         );
         foreach ($paths as $path) {
             if (!file_exists($path['link'])) {


### PR DESCRIPTION
fix issue; `johnpbloch/wordpress` deletes all wp dir including uploads dir when its update by composer

---

#### Proposal

Replace default uploads dir with symlink because `johnpbloch/wordpress` deletes `wp` dir includes `uploads` when its update by composer.
Of course, I think it is good that other better dir instead of `backup/uploads`.
