### PR TITLE
bugfix condition of windows or not

### DIFF
--- a/scripts/Installer.php
+++ b/scripts/Installer.php
@@ -60,7 +60,7 @@ class Installer
             ),
         );
 
-        $isWin = boolval(stristr(PHP_OS, 'WIN'));
+        $isWin = DIRECTORY_SEPARATOR != '/';
 
         // for WIN, replace directory separators.
         if ($isWin) {


### PR DESCRIPTION
[This code](https://github.com/ttskch/WordPress.Skeleton/blob/master/scripts/Installer.php#L63) has a issue. Because `PHP_OS` returns _Dar**win**_ on Mac, `$isWin` pass through even if your machine is Mac.

Then, I modified this bug, but I cannot check it because I have no windows. I'm sorry but could you check it?